### PR TITLE
Landing page, conditional tab rendering, & auth cleanup

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="stylesheet" type="text/css" href="./style/main.css"/>
+  <link href="https://fonts.googleapis.com/css?family=Teko:700" rel="stylesheet">
   <link href='http://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
   <link rel="shortcut icon" href="">
   <title>Document</title>

--- a/client/dist/style/auth.css
+++ b/client/dist/style/auth.css
@@ -30,7 +30,9 @@
 }
 
 .signup-submit-div {
-  padding-top: 30px;
+  margin: 0 auto;
+  padding-top: 2em;
+  width: 9em;
 }
 
 .signup-toggle-trainer {

--- a/client/dist/style/auth.css
+++ b/client/dist/style/auth.css
@@ -1,7 +1,6 @@
 .auth-page {
-  background-color: #424242;
-  width: 100%;
-  height: 100%;
+  background-color: #BDBDBD;
+  height: -webkit-fill-available;
 }
 
 .signup-outer {

--- a/client/dist/style/dashPage.css
+++ b/client/dist/style/dashPage.css
@@ -1,15 +1,26 @@
-#dashPageNavbarTitle{
-  display:flex;
-  padding-left: 15px;
-}
-
 .dashPage{
   display: flex;
   flex-direction: column;
 }
 
-.dashPageNavbarTitleText{
-  font-size: 30px;
+.dashPageNavbarTitle{
+  display: flex;
+  padding-left: 0.56em;
+  font-family: 'Teko';
+  font-size: 2.8em;
+  margin-top: 0.2em;
+}
+
+.dashPageNavbarTitle:hover {
+  cursor: pointer;
+}
+
+#boostTitleNav {
+  color: #49525d;
+}
+
+#boostTitlePTNav {
+  color: #FFEB3B
 }
 
 .avatarPicture{
@@ -20,9 +31,18 @@
   margin-left: 10px;
 }
 
-.navbarUser{
+.navbarUsername:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.navbarUser {
   display: flex;
   align-items: center;
+}
+
+.navbarUser:hover {
+  cursor: pointer;
 }
 
 .dashPageBody{
@@ -33,10 +53,6 @@
   right: 0;
   overflow: auto;
   background: #343F4B;
-}
-
-#navbarTitlePT.dashPageNavbarTitleText{
-  color: #FFEB3B;
 }
 
 .tabs {

--- a/client/dist/style/landingPage.css
+++ b/client/dist/style/landingPage.css
@@ -1,0 +1,28 @@
+#landing-page {
+  background-color: #BDBDBD;
+  height: 100%;
+  height: -webkit-fill-available;
+}
+
+#boostpt-title {
+  font-family: 'Teko', sans-serif;
+  float: left;
+  margin-left: 0.8em;
+  margin-top: 0.3em;
+  font-size: 4em;
+  color: #49525d;
+}
+
+#pt-title {
+  color: #FFEB3B;
+}
+
+.auth-btns {
+  float: right;
+  margin-right: 2.5em;
+  margin-top: 1.5em;
+}
+
+
+
+/*#343F4B*/

--- a/client/dist/style/landingPage.css
+++ b/client/dist/style/landingPage.css
@@ -30,21 +30,36 @@
   margin-top: 4em;
   margin-bottom: 2em;
   text-align: center;
+  clear: both;
 }
 
 .landing-page-subheader {
+  background-color: white;
+  height: 16em;
+}
+
+.landing-page-col-grid {
+  width: 80%;
+  margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  background-color: white;
-  height: 24em;
+
 }
 
 .landing-page-col {
   text-align: center;
   font-family: Lato;
-  font-size: 1.2em;
   color: #49525d;
   margin-top: 3em;
+}
+
+.landing-page-icon {
+  margin-top: 0.8em;
+}
+
+.landing-page-txt {
+  font-size: 0.64em;
+  opacity: 0.8;
 }
 
 .footer {

--- a/client/dist/style/landingPage.css
+++ b/client/dist/style/landingPage.css
@@ -23,6 +23,36 @@
   margin-top: 1.5em;
 }
 
+.landing-page-header {
+  font-family: Lato;
+  font-size: 1.6em;
+  color: #49525d;
+  margin-top: 4em;
+  margin-bottom: 2em;
+  text-align: center;
+}
 
+.landing-page-subheader {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background-color: white;
+  height: 24em;
+}
 
-/*#343F4B*/
+.landing-page-col {
+  text-align: center;
+  font-family: Lato;
+  font-size: 1.2em;
+  color: #49525d;
+  margin-top: 3em;
+}
+
+.footer {
+  position: absolute;
+  margin-bottom: 5px;
+  margin-right: 5px;
+  bottom: 0;
+  right: 0;
+  float: right;
+  color: #49525d;
+}

--- a/client/dist/style/landingPage.css
+++ b/client/dist/style/landingPage.css
@@ -5,7 +5,7 @@
 }
 
 #boostpt-title {
-  font-family: 'Teko', sans-serif;
+  font-family: 'Teko';
   float: left;
   margin-left: 0.8em;
   margin-top: 0.3em;

--- a/client/dist/style/main.css
+++ b/client/dist/style/main.css
@@ -1,4 +1,5 @@
 @import "reset.css";
+@import "landingPage.css";
 @import "auth.css";
 @import "dashPage.css";
 @import "bioPage.css";
@@ -6,3 +7,17 @@
 @import "workoutsView.css";
 @import "clientTab.css";
 @import "messagePage.css";
+
+/*
+
+colors:
+logo blue-grey: #49525d
+logo yellow: #FFEB3B
+light grey: #EEE
+
+standard tab: #C3CAD3
+active tab: #5A6978"
+
+
+
+*/

--- a/client/src/components/auth/loginPage.jsx
+++ b/client/src/components/auth/loginPage.jsx
@@ -5,6 +5,19 @@ import TextField from 'material-ui/TextField';
 import FlatButton from 'material-ui/FlatButton';
 import * as colors from "material-ui/styles/colors";
 
+const authBtnLabelStyle = {
+  fontFamily: 'Lato',
+  fontSize: '1.2em',
+  color: 'white',
+  textTransform: 'none'
+};
+
+const authBtnStyle = {
+  height: '2.4em',
+  width: '6.4em',
+  margin: '1.2em'
+};
+
 const renderTextField = (name, hintText, type, onChange, value) => {
   return (
     <TextField
@@ -36,7 +49,12 @@ class LoginPage extends Component {
               <br />
               <FlatButton
                 type="submit"
-                label="Login"
+                label="Log In"
+                backgroundColor={colors.grey600}
+                hoverColor={colors.grey700}
+                rippleColor={colors.yellow500}
+                labelStyle={authBtnLabelStyle}
+                style={authBtnStyle}
                 onClick={this.props.handleLogin}
               />
             </form>

--- a/client/src/components/auth/signUp.jsx
+++ b/client/src/components/auth/signUp.jsx
@@ -3,8 +3,21 @@ import PropTypes from "prop-types";
 import Paper from 'material-ui/Paper';
 import TextField from 'material-ui/TextField';
 import Toggle from 'material-ui/Toggle';
-import RaisedButton from 'material-ui/RaisedButton';
+import FlatButton from 'material-ui/FlatButton';
 import * as colors from "material-ui/styles/colors";
+
+const authBtnLabelStyle = {
+  fontFamily: 'Lato',
+  fontSize: '1.2em',
+  color: 'white',
+  textTransform: 'none'
+};
+
+const authBtnStyle = {
+  height: '2.4em',
+  width: '6.4em',
+  margin: '1.2em'
+};
 
 const renderTextField = (name, hintText, type, onChange) => {
   return (
@@ -42,9 +55,13 @@ class Signup extends Component {
                   onToggle={(e, isChecked) => this.props.handleToggleButtonChange(isChecked)}
                   onClick={this.props.handleToggleButtonChange}
                 />
-                <RaisedButton
+                <FlatButton
                   label="Sign Up"
-                  primary={true}
+                  backgroundColor={colors.grey600}
+                  hoverColor={colors.grey700}
+                  rippleColor={colors.yellow500}
+                  labelStyle={authBtnLabelStyle}
+                  style={authBtnStyle}
                   onClick={this.props.handleSignupClick}
                 />
               </div>

--- a/client/src/components/auth/signUp.jsx
+++ b/client/src/components/auth/signUp.jsx
@@ -19,6 +19,20 @@ const authBtnStyle = {
   margin: '1.2em'
 };
 
+const toggleStyle = {
+  thumb: {
+    backgroundColor: colors.yellow700
+  },
+  track: {
+    backgroundColor: colors.yellow300
+  }
+};
+
+const toggleLabelStyle = {
+  color: '#49525d',
+  fontFamily: 'Lato'
+};
+
 const renderTextField = (name, hintText, type, onChange) => {
   return (
     <TextField
@@ -51,7 +65,11 @@ class Signup extends Component {
               <div className="signup-submit-div">
                 <Toggle
                   label="I'm a trainer"
+                  defaultToggled={true}
                   labelPosition="right"
+                  thumbSwitchedStyle={toggleStyle.thumb}
+                  trackSwitchedStyle={toggleStyle.track}
+                  labelStyle={toggleLabelStyle}
                   onToggle={(e, isChecked) => this.props.handleToggleButtonChange(isChecked)}
                   onClick={this.props.handleToggleButtonChange}
                 />

--- a/client/src/components/dashPage/index.jsx
+++ b/client/src/components/dashPage/index.jsx
@@ -26,34 +26,45 @@ class DashPage extends Component {
     this.renderActiveTabPage = this.renderActiveTabPage.bind(this);
   }
 
-  renderActiveTabPage() {
+  renderTabs(nTabs, messagesTabIndex) {
+    const tabStyles = Array(nTabs).fill('').map((v, i) => this.props.activeTab === i ? 'active' : 'standard');
+    return (
+      <Tabs className="tabs" inkBarStyle={{display: "none"}} initialSelectedIndex={1}>
+        <Tab label="Schedule" style={tabStyle[tabStyles[0]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
+        <Tab label="Workouts" style={tabStyle[tabStyles[1]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
+        {this.props.user.istrainer ? (
+          <Tab label="Clients" style={tabStyle[tabStyles[2]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
+          ) : (
+            null
+          )
+        }
+        <Tab label="Messages" style={tabStyle[tabStyles[messagesTabIndex]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
+      </Tabs>
+    )
+  }
+
+  renderActiveTabPage(messagesTabIndex) {
     if (this.props.activeTab === 0) {
       // Schedule Page
       return null
     } else if (this.props.activeTab === 1) {
       return <WorkoutsTab />
-    } else if (this.props.activeTab === 2) {
+    } else if (this.props.user.istrainer && this.props.activeTab === 2) {
       return <ClientTabContainer />
-    } else if (this.props.activeTab === 3) {
+    } else if (this.props.activeTab === messagesTabIndex) {
       return <MessagePageContainer/>
     }
   }
 
   render() {
-
-    const tabStyles = Array(4).fill('').map((v, i) => this.props.activeTab === i ? 'active' : 'standard');
-
+    const nTabs = this.props.user.istrainer ? 4 : 3;
+    const messagesTabIndex = this.props.user.istrainer ? 3 : 2;
     return (
         <div className="dashPage">
           <NavbarContainer history={this.props.history}/>
           <div className="dashPageBody">
-            <Tabs className="tabs" inkBarStyle={{display: "none"}} initialSelectedIndex={1}>
-              <Tab label="Schedule" style={tabStyle[tabStyles[0]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
-              <Tab label="Workouts" style={tabStyle[tabStyles[1]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
-              <Tab label="Clients" style={tabStyle[tabStyles[2]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
-              <Tab label="Messages" style={tabStyle[tabStyles[3]]} onActive={this.props.handleTabSelect} disableTouchRipple={true} />
-            </Tabs>
-            {this.renderActiveTabPage()}
+            {this.renderTabs(nTabs, messagesTabIndex)}
+            {this.renderActiveTabPage(messagesTabIndex)}
           </div>
         </div>
     )

--- a/client/src/components/dashPage/navbar.jsx
+++ b/client/src/components/dashPage/navbar.jsx
@@ -20,9 +20,9 @@ class Navbar extends Component{
     return(
       <Toolbar style={toolbarStyle} className="dashPageNavbar">
         <ToolbarGroup firstChild={true}>
-          <div id="dashPageNavbarTitle" onClick={this.props.handleTitleClick}>
-            <span id="boostTitle" className="dashPageNavbarTitleText"> Boost </span>
-            <span id="navbarTitlePT" className="dashPageNavbarTitleText"> PT </span>
+          <div className="dashPageNavbarTitle" onClick={this.props.handleTitleClick}>
+            <span id="boostTitleNav">Boost</span>
+            <span id="boostTitlePTNav">PT</span>
           </div>
         </ToolbarGroup>
         <ToolbarGroup>

--- a/client/src/components/landingPage/index.jsx
+++ b/client/src/components/landingPage/index.jsx
@@ -50,6 +50,14 @@ class LandingPage extends Component {
             />
           </Link>
         </div>
+        <br />
+        <h3 className="landing-page-header">Personal Training Client Management, Simplified</h3>
+        <div className="landing-page-subheader">
+          <h3 className="landing-page-col">Schedule Workouts</h3>
+          <h3 className="landing-page-col">Log Exercises</h3>
+          <h3 className="landing-page-col">Share with your network</h3>
+        </div>
+        <span className="footer">Copyright &copy; 2018 BoostPT. All Rights Reserved.</span>
       </div>
     )
   }

--- a/client/src/components/landingPage/index.jsx
+++ b/client/src/components/landingPage/index.jsx
@@ -1,7 +1,10 @@
-import React, { Component } from 'react';
+import React, {Component, Fragment} from 'react';
 import { connect } from 'react-redux';
-import FlatButton from 'material-ui/FlatButton';
 import { Link } from 'react-router-dom';
+import FlatButton from 'material-ui/FlatButton';
+import CalendarIcon from 'material-ui/svg-icons/action/date-range';
+import Bullets from 'material-ui/svg-icons/editor/format-list-bulleted';
+import DashIcon from 'material-ui/svg-icons/action/dashboard';
 import * as colors from 'material-ui/styles/colors';
 
 const authBtnLabelStyle = {
@@ -14,6 +17,13 @@ const authBtnStyle = {
   height: '2.4em',
   width: '6.4em',
   margin: '1.2em'
+};
+
+const iconStyle = {
+  width: '6em',
+  height: '6em',
+  color: '#49525d',
+  opacity: 0.65
 };
 
 class LandingPage extends Component {
@@ -53,9 +63,21 @@ class LandingPage extends Component {
         <br />
         <h3 className="landing-page-header">Personal Training Client Management, Simplified</h3>
         <div className="landing-page-subheader">
-          <h3 className="landing-page-col">Schedule Workouts</h3>
-          <h3 className="landing-page-col">Log Exercises</h3>
-          <h3 className="landing-page-col">Share with your network</h3>
+          <div className="landing-page-col-grid">
+            <div className="landing-page-col">
+              <h3>Schedule Workouts</h3>
+              <CalendarIcon className="landing-page-icon" style={iconStyle} />
+              <p className="landing-page-txt"></p>
+            </div>
+            <div className="landing-page-col">
+              <h3>Log Exercises</h3>
+              <Bullets className="landing-page-icon" style={iconStyle} />
+            </div>
+            <div className="landing-page-col">
+              <h3>Organize Client Programs</h3>
+              <DashIcon className="landing-page-icon" style={iconStyle} />
+            </div>
+          </div>
         </div>
         <span className="footer">Copyright &copy; 2018 BoostPT. All Rights Reserved.</span>
       </div>

--- a/client/src/components/landingPage/index.jsx
+++ b/client/src/components/landingPage/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FlatButton from 'material-ui/FlatButton';
 import { Link } from 'react-router-dom';
 import * as colors from 'material-ui/styles/colors';
@@ -16,6 +17,13 @@ const authBtnStyle = {
 };
 
 class LandingPage extends Component {
+
+  componentDidMount() {
+    if (this.props.user) {
+      this.props.history.push('/dash');
+    }
+  }
+
   render() {
     return (
       <div id="landing-page">
@@ -47,5 +55,10 @@ class LandingPage extends Component {
   }
 }
 
+const mapStateToProps = (state) => {
+  return {
+    user: state.auth.user
+  }
+};
 
-export default LandingPage;
+export default connect(mapStateToProps, null)(LandingPage);

--- a/client/src/components/landingPage/index.jsx
+++ b/client/src/components/landingPage/index.jsx
@@ -1,33 +1,47 @@
 import React, { Component } from 'react';
-import {Toolbar, ToolbarGroup, ToolbarTitle} from 'material-ui/Toolbar';
 import FlatButton from 'material-ui/FlatButton';
 import { Link } from 'react-router-dom';
-import RaisedButton from 'material-ui/RaisedButton';
 import * as colors from 'material-ui/styles/colors';
 
-const toolbarStyle = {
-  backgroundColor: colors.grey900
-}
+const authBtnLabelStyle = {
+  fontFamily: 'Lato',
+  fontSize: '1.2em',
+  textTransform: 'none'
+};
 
-const toolbarTitleStyle = {
-  color: colors.yellow500
-}
+const authBtnStyle = {
+  height: '2.4em',
+  width: '6.4em',
+  margin: '1.2em'
+};
 
 class LandingPage extends Component {
   render() {
     return (
-      //this toolbar may need to be a separate component
-      <div>
-      <Toolbar style={toolbarStyle} className="landingPageToolBar">
-        <ToolbarGroup firstChild={true}>
-          <ToolbarTitle style={toolbarTitleStyle} text="BoostPT"/>
-        </ToolbarGroup>
-
-        <ToolbarGroup>
-          <Link to="/signup"><RaisedButton label="Signup" /></Link>
-          <Link to='/login'><RaisedButton label="Login" /></Link>
-        </ToolbarGroup>
-      </Toolbar>
+      <div id="landing-page">
+        <h2 id="boostpt-title">Boost<span id="pt-title">PT</span></h2>
+        <div className="auth-btns">
+          <Link to="/signup">
+            <FlatButton
+              label="Sign Up"
+              backgroundColor={colors.grey600}
+              hoverColor={colors.grey700}
+              rippleColor={colors.yellow500}
+              labelStyle={authBtnLabelStyle}
+              style={authBtnStyle}
+            />
+          </Link>
+          <Link to='/login'>
+            <FlatButton
+              label="Log In"
+              backgroundColor={colors.grey600}
+              hoverColor={colors.grey700}
+              rippleColor={colors.yellow500}
+              labelStyle={authBtnLabelStyle}
+              style={authBtnStyle}
+            />
+          </Link>
+        </div>
       </div>
     )
   }

--- a/client/src/reducers/changePictureReducer.js
+++ b/client/src/reducers/changePictureReducer.js
@@ -3,7 +3,6 @@ import {
 } from '../actions/types'
 
 export default function(state = {}, action) {
-  console.log("action payload",action.payload);
   if(action.type === CHANGE_USER_PICTURE){
     return Object.assign({}, state, {
       user: action.payload 


### PR DESCRIPTION
- Re-scaffolded landing page
- Users previously logged in get rerouted to /dash when loading / path
- Signup page toggle button is centered, styled, and defaulted to true
- Styled navbar title and hover reactions
- Client tab only renders if user is a trainer

NOTE: seeded account aaron@gmail.com is not a trainer currently.